### PR TITLE
add normal names for functions with "'"

### DIFF
--- a/lib/js/src/tea_debug.js
+++ b/lib/js/src/tea_debug.js
@@ -715,7 +715,7 @@ function debug(string_of_msg, update, view, subscriptions, shutdown) {
         return JSON.stringify(formatValue(v), null, 2);
       });
     return Tea_html2.aside(undefined, undefined, {
-                hd: Tea_html2.Attributes.class$p("details"),
+                hd: Tea_html2.Attributes.$$class("details"),
                 tl: /* [] */0
               }, {
                 hd: {
@@ -728,7 +728,7 @@ function debug(string_of_msg, update, view, subscriptions, shutdown) {
   var view_history = function (model, selected_index) {
     var count = List.length(model.history);
     return Tea_html2.ul(undefined, undefined, {
-                hd: Tea_html2.Attributes.class$p("history"),
+                hd: Tea_html2.Attributes.$$class("history"),
                 tl: /* [] */0
               }, List.mapi((function (i, param) {
                       var selected = i === selected_index;
@@ -787,7 +787,7 @@ function debug(string_of_msg, update, view, subscriptions, shutdown) {
                                       }),
                                   tl: {
                                     hd: Tea_html2.span(undefined, undefined, {
-                                          hd: Tea_html2.Attributes.class$p("message"),
+                                          hd: Tea_html2.Attributes.$$class("message"),
                                           tl: /* [] */0
                                         }, {
                                           hd: {
@@ -798,7 +798,7 @@ function debug(string_of_msg, update, view, subscriptions, shutdown) {
                                         }),
                                     tl: {
                                       hd: Tea_html2.span(undefined, undefined, {
-                                            hd: Tea_html2.Attributes.class$p("index"),
+                                            hd: Tea_html2.Attributes.$$class("index"),
                                             tl: /* [] */0
                                           }, {
                                             hd: {
@@ -852,7 +852,7 @@ function debug(string_of_msg, update, view, subscriptions, shutdown) {
                         tl: {
                           hd: Tea_html2.nav(undefined, undefined, /* [] */0, {
                                 hd: Tea_html2.div(undefined, undefined, {
-                                      hd: Tea_html2.Attributes.class$p("toggle"),
+                                      hd: Tea_html2.Attributes.$$class("toggle"),
                                       tl: {
                                         hd: Tea_html2.Events.onClick(/* TogglePaused */0),
                                         tl: {

--- a/lib/js/src/tea_html.js
+++ b/lib/js/src/tea_html.js
@@ -243,7 +243,7 @@ function select(keyOpt, uniqueOpt, props, nodes) {
   return Vdom.fullnode("", "select", key, unique, props, nodes);
 }
 
-function option$p(keyOpt, uniqueOpt, props, nodes) {
+function option(keyOpt, uniqueOpt, props, nodes) {
   var key = keyOpt !== undefined ? keyOpt : "";
   var unique = uniqueOpt !== undefined ? uniqueOpt : "";
   return Vdom.fullnode("", "option", key, unique, props, nodes);
@@ -483,7 +483,7 @@ function embed(keyOpt, uniqueOpt, props, nodes) {
   return Vdom.fullnode("", "embed", key, unique, props, nodes);
 }
 
-function object$p(keyOpt, uniqueOpt, props, nodes) {
+function object(keyOpt, uniqueOpt, props, nodes) {
   var key = keyOpt !== undefined ? keyOpt : "";
   var unique = uniqueOpt !== undefined ? uniqueOpt : "";
   return Vdom.fullnode("", "object", key, unique, props, nodes);
@@ -531,7 +531,7 @@ function abbr(keyOpt, uniqueOpt, props, nodes) {
   return Vdom.fullnode("", "abbr", key, unique, props, nodes);
 }
 
-function var$p(keyOpt, uniqueOpt, props, nodes) {
+function $$var(keyOpt, uniqueOpt, props, nodes) {
   var key = keyOpt !== undefined ? keyOpt : "";
   var unique = uniqueOpt !== undefined ? uniqueOpt : "";
   return Vdom.fullnode("", "var", key, unique, props, nodes);
@@ -632,7 +632,7 @@ function title(str) {
         };
 }
 
-function class$p(name) {
+function $$class(name) {
   return {
           TAG: /* RawProp */0,
           _0: "className",
@@ -753,7 +753,7 @@ function action(a) {
         };
 }
 
-function method$p(m) {
+function method(m) {
   return {
           TAG: /* RawProp */0,
           _0: "method",
@@ -1043,7 +1043,7 @@ exports.td = td;
 exports.progress = progress;
 exports.img = img;
 exports.select = select;
-exports.option$p = option$p;
+exports.option = option;
 exports.form = form;
 exports.nav = nav;
 exports.main = main;
@@ -1083,7 +1083,7 @@ exports.video = video;
 exports.source = source;
 exports.track = track;
 exports.embed = embed;
-exports.object$p = object$p;
+exports.object = object;
 exports.param = param;
 exports.ins = ins;
 exports.del = del;
@@ -1091,7 +1091,7 @@ exports.small = small;
 exports.cite = cite;
 exports.dfn = dfn;
 exports.abbr = abbr;
-exports.var$p = var$p;
+exports.$$var = $$var;
 exports.samp = samp;
 exports.kbd = kbd;
 exports.s = s;
@@ -1107,7 +1107,7 @@ exports.id = id;
 exports.href = href;
 exports.src = src;
 exports.title = title;
-exports.class$p = class$p;
+exports.$$class = $$class;
 exports.classList = classList;
 exports.type$p = type$p;
 exports.style = style;
@@ -1121,7 +1121,7 @@ exports.for$p = for$p;
 exports.hidden = hidden;
 exports.target = target;
 exports.action = action;
-exports.method$p = method$p;
+exports.method = method;
 exports.onCB = onCB;
 exports.onMsg = onMsg;
 exports.onInputOpt = onInputOpt;

--- a/lib/js/src/tea_html2.js
+++ b/lib/js/src/tea_html2.js
@@ -253,7 +253,7 @@ function select(keyOpt, uniqueOpt, props, nodes) {
   return Vdom.fullnode("", "select", key, unique, props, nodes);
 }
 
-function option$p(keyOpt, uniqueOpt, props, nodes) {
+function option(keyOpt, uniqueOpt, props, nodes) {
   var key = keyOpt !== undefined ? keyOpt : "";
   var unique = uniqueOpt !== undefined ? uniqueOpt : "";
   return Vdom.fullnode("", "option", key, unique, props, nodes);
@@ -469,7 +469,7 @@ function embed(keyOpt, uniqueOpt, props, nodes) {
   return Vdom.fullnode("", "embed", key, unique, props, nodes);
 }
 
-function object$p(keyOpt, uniqueOpt, props, nodes) {
+function object(keyOpt, uniqueOpt, props, nodes) {
   var key = keyOpt !== undefined ? keyOpt : "";
   var unique = uniqueOpt !== undefined ? uniqueOpt : "";
   return Vdom.fullnode("", "object", key, unique, props, nodes);
@@ -523,7 +523,7 @@ function time(keyOpt, uniqueOpt, props, nodes) {
   return Vdom.fullnode("", "time", key, unique, props, nodes);
 }
 
-function var$p(keyOpt, uniqueOpt, props, nodes) {
+function $$var(keyOpt, uniqueOpt, props, nodes) {
   var key = keyOpt !== undefined ? keyOpt : "";
   var unique = uniqueOpt !== undefined ? uniqueOpt : "";
   return Vdom.fullnode("", "var", key, unique, props, nodes);
@@ -664,7 +664,7 @@ function styles(s) {
         };
 }
 
-function class$p(name) {
+function $$class(name) {
   return {
           TAG: /* RawProp */0,
           _0: "className",
@@ -874,7 +874,7 @@ function maxlength(n) {
         };
 }
 
-function method$p(m) {
+function method(m) {
   return {
           TAG: /* RawProp */0,
           _0: "method",
@@ -1553,7 +1553,7 @@ var Attributes = {
   noProp: /* NoProp */0,
   style: style$1,
   styles: styles,
-  class$p: class$p,
+  $$class: $$class,
   classList: classList,
   id: id,
   title: title$1,
@@ -1575,7 +1575,7 @@ var Attributes = {
   list: list,
   minlength: minlength,
   maxlength: maxlength,
-  method$p: method$p,
+  method: method,
   multiple: multiple,
   name: name,
   novalidate: novalidate,
@@ -1848,7 +1848,7 @@ exports.input$p = input$p;
 exports.textarea = textarea;
 exports.button = button;
 exports.select = select;
-exports.option$p = option$p;
+exports.option = option;
 exports.optgroup = optgroup;
 exports.label = label;
 exports.fieldset = fieldset;
@@ -1884,7 +1884,7 @@ exports.video = video;
 exports.source = source;
 exports.track = track;
 exports.embed = embed;
-exports.object$p = object$p;
+exports.object = object;
 exports.param = param;
 exports.ins = ins;
 exports.del = del;
@@ -1893,7 +1893,7 @@ exports.cite = cite;
 exports.dfn = dfn;
 exports.abbr = abbr;
 exports.time = time;
-exports.var$p = var$p;
+exports.$$var = $$var;
 exports.samp = samp;
 exports.kbd = kbd;
 exports.s = s;

--- a/lib/js/src/tea_http.js
+++ b/lib/js/src/tea_http.js
@@ -71,7 +71,7 @@ function request(rawRequest) {
 function getString(url) {
   return /* Request */{
           _0: {
-            "method'": "GET",
+            method: "GET",
             headers: /* [] */0,
             url: url,
             body: /* EmptyBody */0,
@@ -649,7 +649,7 @@ function toTask(param) {
   var body = request.body;
   var url = request.url;
   var headers = request.headers;
-  var method$p = request["method'"];
+  var method = request.method;
   return /* Task */{
           _0: (function (cb) {
               var enqResError = function (result) {
@@ -730,7 +730,7 @@ function toTask(param) {
               };
               xhr.onload = cb$4;
               try {
-                Web_xmlhttprequest.open_(method$p, url, undefined, undefined, undefined, xhr);
+                Web_xmlhttprequest.open_(method, url, undefined, undefined, undefined, xhr);
               }
               catch (exn){
                 enqResError({
@@ -1320,7 +1320,7 @@ function send(resultToMessage, param) {
   var body = request.body;
   var url = request.url;
   var headers = request.headers;
-  var method$p = request["method'"];
+  var method = request.method;
   return {
           TAG: /* EnqueueCall */2,
           _0: (function (callbacks) {
@@ -1421,7 +1421,7 @@ function send(resultToMessage, param) {
               };
               xhr.onload = cb$3;
               try {
-                Web_xmlhttprequest.open_(method$p, url, undefined, undefined, undefined, xhr);
+                Web_xmlhttprequest.open_(method, url, undefined, undefined, undefined, xhr);
               }
               catch (exn){
                 enqResError({

--- a/lib/js/src/tea_svg_attributes.js
+++ b/lib/js/src/tea_svg_attributes.js
@@ -146,7 +146,7 @@ function bbox(v) {
         };
 }
 
-function begin$p(v) {
+function begin(v) {
   return {
           TAG: /* Attribute */1,
           _0: "",
@@ -191,7 +191,7 @@ function capHeight(v) {
         };
 }
 
-function class$p(v) {
+function $$class(v) {
   return {
           TAG: /* Attribute */1,
           _0: "",
@@ -335,7 +335,7 @@ function elevation(v) {
         };
 }
 
-function end$p(v) {
+function end(v) {
   return {
           TAG: /* Attribute */1,
           _0: "",
@@ -758,7 +758,7 @@ function media(v) {
         };
 }
 
-function method$p(v) {
+function method(v) {
   return {
           TAG: /* Attribute */1,
           _0: "",
@@ -1352,7 +1352,7 @@ function title(v) {
         };
 }
 
-function to$p(v) {
+function to(v) {
   return {
           TAG: /* Attribute */1,
           _0: "",
@@ -2295,12 +2295,12 @@ exports.azimuth = azimuth;
 exports.baseFrequency = baseFrequency;
 exports.baseProfile = baseProfile;
 exports.bbox = bbox;
-exports.begin$p = begin$p;
+exports.begin = begin;
 exports.bias = bias;
 exports.by = by;
 exports.calcMode = calcMode;
 exports.capHeight = capHeight;
-exports.class$p = class$p;
+exports.$$class = $$class;
 exports.clipPathUnits = clipPathUnits;
 exports.contentScriptType = contentScriptType;
 exports.contentStyleType = contentStyleType;
@@ -2316,7 +2316,7 @@ exports.dx = dx;
 exports.dy = dy;
 exports.edgeMode = edgeMode;
 exports.elevation = elevation;
-exports.end$p = end$p;
+exports.end = end;
 exports.exponent = exponent;
 exports.externalResourcesRequired = externalResourcesRequired;
 exports.filterRes = filterRes;
@@ -2363,7 +2363,7 @@ exports.maskUnits = maskUnits;
 exports.mathematical = mathematical;
 exports.max = max;
 exports.media = media;
-exports.method$p = method$p;
+exports.method = method;
 exports.min = min;
 exports.mode = mode;
 exports.name = name;
@@ -2429,7 +2429,7 @@ exports.targetX = targetX;
 exports.targetY = targetY;
 exports.textLength = textLength;
 exports.title = title;
-exports.to$p = to$p;
+exports.to = to;
 exports.transform = transform;
 exports.type$p = type$p;
 exports.u1 = u1;

--- a/lib/js/src/web_window_history.js
+++ b/lib/js/src/web_window_history.js
@@ -29,10 +29,10 @@ function forward($$window) {
   
 }
 
-function go($$window, to$p) {
+function go($$window, to) {
   var history = $$window.history;
   if (history !== undefined) {
-    history.go(to$p);
+    history.go(to);
     return ;
   }
   

--- a/lib/js/src/web_xmlhttprequest.js
+++ b/lib/js/src/web_xmlhttprequest.js
@@ -83,11 +83,11 @@ function getResponseHeader(key, x) {
   return Caml_option.null_to_opt(Curry._1(x.getResponse, key));
 }
 
-function open_(method$p, url, asyncOpt, userOpt, passwordOpt, x) {
+function open_(method, url, asyncOpt, userOpt, passwordOpt, x) {
   var async = asyncOpt !== undefined ? asyncOpt : true;
   var user = userOpt !== undefined ? userOpt : "";
   var password = passwordOpt !== undefined ? passwordOpt : "";
-  x._open(method$p, url, async, user, password);
+  x._open(method, url, async, user, password);
   
 }
 

--- a/src/tea_debug.res
+++ b/src/tea_debug.res
@@ -264,7 +264,7 @@ let debug = (
         return JSON.stringify(formatValue(v), null, 2);
       }
     `)
-    aside(list{A.class'("details")}, list{model |> format |> text})
+    aside(list{A.class("details")}, list{model |> format |> text})
   }
 
   let view_history = (model, selected_index) => {
@@ -272,7 +272,7 @@ let debug = (
     module A = Tea_html2.Attributes
     module E = Tea_html2.Events
     let count = List.length(model.history)
-    \"@@"(ul(list{A.class'("history")}), List.mapi((i, (msg, cmodel)) => {
+    \"@@"(ul(list{A.class("history")}), List.mapi((i, (msg, cmodel)) => {
         let selected = i == selected_index
         li(
           list{
@@ -297,8 +297,8 @@ let debug = (
                 },
               },
             ),
-            span(list{A.class'("message")}, list{text(msg)}),
-            span(list{A.class'("index")}, list{count - i |> string_of_int |> text}),
+            span(list{A.class("message")}, list{text(msg)}),
+            span(list{A.class("index")}, list{count - i |> string_of_int |> text}),
           },
         )
       }, model.history))
@@ -327,7 +327,7 @@ let debug = (
               list{
                 div(
                   list{
-                    A.class'("toggle"),
+                    A.class("toggle"),
                     E.onClick(TogglePaused),
                     if paused {
                       A.title("click to resume")

--- a/src/tea_html.res
+++ b/src/tea_html.res
@@ -104,7 +104,7 @@ let img = (~key="", ~unique="", props, nodes) => fullnode("", "img", key, unique
 let select = (~key="", ~unique="", props, nodes) =>
   fullnode("", "select", key, unique, props, nodes)
 
-let option' = (~key="", ~unique="", props, nodes) =>
+let option = (~key="", ~unique="", props, nodes) =>
   fullnode("", "option", key, unique, props, nodes)
 
 let form = (~key="", ~unique="", props, nodes) => fullnode("", "form", key, unique, props, nodes)
@@ -202,7 +202,7 @@ let track = (~key="", ~unique="", props, nodes) => fullnode("", "track", key, un
 
 let embed = (~key="", ~unique="", props, nodes) => fullnode("", "embed", key, unique, props, nodes)
 
-let object' = (~key="", ~unique="", props, nodes) =>
+let object = (~key="", ~unique="", props, nodes) =>
   fullnode("", "object", key, unique, props, nodes)
 
 let param = (~key="", ~unique="", props, nodes) => fullnode("", "param", key, unique, props, nodes)
@@ -219,7 +219,7 @@ let dfn = (~key="", ~unique="", props, nodes) => fullnode("", "dfn", key, unique
 
 let abbr = (~key="", ~unique="", props, nodes) => fullnode("", "abbr", key, unique, props, nodes)
 
-let var' = (~key="", ~unique="", props, nodes) => fullnode("", "var", key, unique, props, nodes)
+let var = (~key="", ~unique="", props, nodes) => fullnode("", "var", key, unique, props, nodes)
 
 let samp = (~key="", ~unique="", props, nodes) => fullnode("", "samp", key, unique, props, nodes)
 
@@ -256,14 +256,14 @@ let src = str => attribute("", "src", str)
 
 let title = str => attribute("", "title", str)
 
-let class' = name => prop("className", name)
+let class = name => prop("className", name)
 
 let classList = classes =>
   classes
   |> List.filter(((_fst, snd)) => snd)
   |> List.map(((fst, _snd)) => fst)
   |> String.concat(" ")
-  |> class'
+  |> class
 
 let type' = typ => prop("type", typ)
 
@@ -304,7 +304,7 @@ let target = t => prop("target", t)
 
 let action = a => prop("action", a)
 
-let method' = m => prop("method", m)
+let method = m => prop("method", m)
 
 /* Events */
 

--- a/src/tea_html.resi
+++ b/src/tea_html.resi
@@ -105,7 +105,7 @@ let img: (~key: string=?, ~unique: string=?, Vdom.properties<'msg>, list<Vdom.t<
 
 let select: (~key: string=?, ~unique: string=?, Vdom.properties<'msg>, list<Vdom.t<'msg>>) => Vdom.t<'msg>
 
-let option': (~key: string=?, ~unique: string=?, Vdom.properties<'msg>, list<Vdom.t<'msg>>) => Vdom.t<'msg,>
+let option: (~key: string=?, ~unique: string=?, Vdom.properties<'msg>, list<Vdom.t<'msg>>) => Vdom.t<'msg,>
 
 let form: (~key: string=?, ~unique: string=?, Vdom.properties<'msg>, list<Vdom.t<'msg>>) => Vdom.t<'msg>
 
@@ -185,7 +185,7 @@ let track: (~key: string=?, ~unique: string=?, Vdom.properties<'msg>, list<Vdom.
 
 let embed: (~key: string=?, ~unique: string=?, Vdom.properties<'msg>, list<Vdom.t<'msg>>) => Vdom.t<'msg>
 
-let object': (~key: string=?, ~unique: string=?, Vdom.properties<'msg>, list<Vdom.t<'msg>>) => Vdom.t<'msg,>
+let object: (~key: string=?, ~unique: string=?, Vdom.properties<'msg>, list<Vdom.t<'msg>>) => Vdom.t<'msg,>
 
 let param: (~key: string=?, ~unique: string=?, Vdom.properties<'msg>, list<Vdom.t<'msg>>) => Vdom.t<'msg>
 
@@ -204,7 +204,7 @@ let dfn: (~key: string=?, ~unique: string=?, Vdom.properties<'msg>, list<Vdom.t<
 
 let abbr: (~key: string=?, ~unique: string=?, Vdom.properties<'msg>, list<Vdom.t<'msg>>) => Vdom.t<'msg>
 
-let var': (~key: string=?, ~unique: string=?, Vdom.properties<'msg>, list<Vdom.t<'msg>>) => Vdom.t<'msg>
+let var: (~key: string=?, ~unique: string=?, Vdom.properties<'msg>, list<Vdom.t<'msg>>) => Vdom.t<'msg>
 
 let samp: (~key: string=?, ~unique: string=?, Vdom.properties<'msg>, list<Vdom.t<'msg>>) => Vdom.t<'msg>
 
@@ -241,7 +241,7 @@ let src: string => Vdom.property<'msg>
 
 let title: string => Vdom.property<'msg>
 
-let class': string => Vdom.property<'msg>
+let class: string => Vdom.property<'msg>
 
 let classList: list<(string, bool)> => Vdom.property<'msg>
 
@@ -269,7 +269,7 @@ let target: string => Vdom.property<'msg>
 
 let action: string => Vdom.property<'msg>
 
-let method': string => Vdom.property<'msg>
+let method: string => Vdom.property<'msg>
 
 
 

--- a/src/tea_html2.res
+++ b/src/tea_html2.res
@@ -113,7 +113,7 @@ let button = (~key="", ~unique="", props, nodes) =>
 let select = (~key="", ~unique="", props, nodes) =>
   fullnode("", "select", key, unique, props, nodes)
 
-let option' = (~key="", ~unique="", props, nodes) =>
+let option = (~key="", ~unique="", props, nodes) =>
   fullnode("", "option", key, unique, props, nodes)
 
 let optgroup = (~key="", ~unique="", props, nodes) =>
@@ -215,7 +215,7 @@ let track = (~key="", ~unique="", props, nodes) => fullnode("", "track", key, un
 
 let embed = (~key="", ~unique="", props, nodes) => fullnode("", "embed", key, unique, props, nodes)
 
-let object' = (~key="", ~unique="", props, nodes) =>
+let object = (~key="", ~unique="", props, nodes) =>
   fullnode("", "object", key, unique, props, nodes)
 
 let param = (~key="", ~unique="", props, nodes) => fullnode("", "param", key, unique, props, nodes)
@@ -238,7 +238,7 @@ let abbr = (~key="", ~unique="", props, nodes) => fullnode("", "abbr", key, uniq
 
 let time = (~key="", ~unique="", props, nodes) => fullnode("", "time", key, unique, props, nodes)
 
-let var' = (~key="", ~unique="", props, nodes) => fullnode("", "var", key, unique, props, nodes)
+let var = (~key="", ~unique="", props, nodes) => fullnode("", "var", key, unique, props, nodes)
 
 let samp = (~key="", ~unique="", props, nodes) => fullnode("", "samp", key, unique, props, nodes)
 
@@ -301,14 +301,14 @@ module Attributes = {
 
   @@ocaml.text(" {1 Super common attributes} ")
 
-  let class' = name => prop("className", name)
+  let class = name => prop("className", name)
 
   let classList = classes =>
     classes
     |> List.filter(((_fst, snd)) => snd)
     |> List.map(((fst, _snd)) => fst)
     |> String.concat(" ")
-    |> class'
+    |> class
 
   let id = str => prop("id", str)
 
@@ -387,7 +387,7 @@ module Attributes = {
 
   let maxlength = n => attribute("", "maxlength", string_of_int(n))
 
-  let method' = m => prop("method", m)
+  let method = m => prop("method", m)
 
   let multiple = b =>
     if b {

--- a/src/tea_html2.resi
+++ b/src/tea_html2.resi
@@ -101,7 +101,7 @@ let button: (~key: string=?, ~unique: string=?, Vdom.properties<'msg>, list<Vdom
 
 let select: (~key: string=?, ~unique: string=?, Vdom.properties<'msg>, list<Vdom.t<'msg>>) => Vdom.t<'msg>
 
-let option': (~key: string=?, ~unique: string=?, Vdom.properties<'msg>, list<Vdom.t<'msg>>) => Vdom.t<'msg,>
+let option: (~key: string=?, ~unique: string=?, Vdom.properties<'msg>, list<Vdom.t<'msg>>) => Vdom.t<'msg,>
 
 let optgroup: (~key: string=?, ~unique: string=?, Vdom.properties<'msg>, list<Vdom.t<'msg>>) => Vdom.t<'msg,>
 
@@ -190,7 +190,7 @@ let track: (~key: string=?, ~unique: string=?, Vdom.properties<'msg>, list<Vdom.
 
 let embed: (~key: string=?, ~unique: string=?, Vdom.properties<'msg>, list<Vdom.t<'msg>>) => Vdom.t<'msg>
 
-let object': (~key: string=?, ~unique: string=?, Vdom.properties<'msg>, list<Vdom.t<'msg>>) => Vdom.t<'msg,>
+let object: (~key: string=?, ~unique: string=?, Vdom.properties<'msg>, list<Vdom.t<'msg>>) => Vdom.t<'msg,>
 
 let param: (~key: string=?, ~unique: string=?, Vdom.properties<'msg>, list<Vdom.t<'msg>>) => Vdom.t<'msg>
 
@@ -214,7 +214,7 @@ let abbr: (~key: string=?, ~unique: string=?, Vdom.properties<'msg>, list<Vdom.t
 
 let time: (~key: string=?, ~unique: string=?, Vdom.properties<'msg>, list<Vdom.t<'msg>>) => Vdom.t<'msg>
 
-let var': (~key: string=?, ~unique: string=?, Vdom.properties<'msg>, list<Vdom.t<'msg>>) => Vdom.t<'msg>
+let var: (~key: string=?, ~unique: string=?, Vdom.properties<'msg>, list<Vdom.t<'msg>>) => Vdom.t<'msg>
 
 let samp: (~key: string=?, ~unique: string=?, Vdom.properties<'msg>, list<Vdom.t<'msg>>) => Vdom.t<'msg>
 
@@ -277,7 +277,7 @@ module Attributes: {
 
 
 
-  let class': string => Vdom.property<'msg>
+  let class: string => Vdom.property<'msg>
 
   let classList: list<(string, bool)> => Vdom.property<'msg>
 
@@ -327,7 +327,7 @@ module Attributes: {
 
   let maxlength: int => Vdom.property<'msg>
 
-  let method': string => Vdom.property<'msg>
+  let method: string => Vdom.property<'msg>
 
   let multiple: bool => Vdom.property<'msg>
 

--- a/src/tea_http.res
+++ b/src/tea_http.res
@@ -51,7 +51,7 @@ let emptyRequestEvents = {
 }
 
 type rawRequest<'res> = {
-  method': string,
+  method: string,
   headers: list<header>,
   url: string,
   body: requestBody,
@@ -80,7 +80,7 @@ let request = rawRequest => Request(rawRequest, None)
 
 let getString = url =>
   request({
-    method': "GET",
+    method: "GET",
     headers: list{},
     url: url,
     body: Web.XMLHttpRequest.EmptyBody,
@@ -91,7 +91,7 @@ let getString = url =>
 
 let toTask = (Request(request, _maybeEvents)) => {
   module StringMap = Map.Make(String)
-  let {method', headers, url, body, expect, timeout, withCredentials} = request
+  let {method, headers, url, body, expect, timeout, withCredentials} = request
   let Expect(typ, responseToResult) = expect
   Tea_task.nativeBinding(cb => {
     let enqRes = (result, _ev) => cb(result)
@@ -123,7 +123,7 @@ let toTask = (Request(request, _maybeEvents)) => {
         }
       }
     })
-    let () = try Web.XMLHttpRequest.open_(method', url, xhr) catch {
+    let () = try Web.XMLHttpRequest.open_(method, url, xhr) catch {
     | _ => enqResError(BadUrl(url), ())
     }
     let () = {
@@ -142,7 +142,7 @@ let toTask = (Request(request, _maybeEvents)) => {
 
 let send = (resultToMessage, Request(request, maybeEvents)) => {
   module StringMap = Map.Make(String)
-  let {method', headers, url, body, expect, timeout, withCredentials} = request
+  let {method, headers, url, body, expect, timeout, withCredentials} = request
   let Expect(typ, responseToResult) = expect
   Tea_cmd.call(callbacks => {
     let enqRes = (result, _ev) => {
@@ -189,7 +189,7 @@ let send = (resultToMessage, Request(request, maybeEvents)) => {
         }
       }
     })
-    let () = try Web.XMLHttpRequest.open_(method', url, xhr) catch {
+    let () = try Web.XMLHttpRequest.open_(method, url, xhr) catch {
     | _ => enqResError(BadUrl(url), ())
     }
     let () = {

--- a/src/tea_http.resi
+++ b/src/tea_http.resi
@@ -31,7 +31,7 @@ type requestEvents<'msg> = {
 
 let emptyRequestEvents: requestEvents<'msg>
 type rawRequest<'res> = {
-  method': string,
+  method: string,
   headers: list<header>,
   url: string,
   body: requestBody,

--- a/src/tea_svg_attributes.res
+++ b/src/tea_svg_attributes.res
@@ -34,7 +34,7 @@ let baseProfile = v => attribute("", "baseProfile", v)
 
 let bbox = v => attribute("", "bbox", v)
 
-let begin' = v => attribute("", "begin", v)
+let begin = v => attribute("", "begin", v)
 
 let bias = v => attribute("", "bias", v)
 
@@ -44,7 +44,7 @@ let calcMode = v => attribute("", "calcMode", v)
 
 let capHeight = v => attribute("", "cap-height", v)
 
-let class' = v => attribute("", "class", v)
+let class = v => attribute("", "class", v)
 
 let clipPathUnits = v => attribute("", "clipPathUnits", v)
 
@@ -76,7 +76,7 @@ let edgeMode = v => attribute("", "edgeMode", v)
 
 let elevation = v => attribute("", "elevation", v)
 
-let end' = v => attribute("", "end", v)
+let end = v => attribute("", "end", v)
 
 let exponent = v => attribute("", "exponent", v)
 
@@ -170,7 +170,7 @@ let max = v => attribute("", "max", v)
 
 let media = v => attribute("", "media", v)
 
-let method' = v => attribute("", "method", v)
+let method = v => attribute("", "method", v)
 
 let min = v => attribute("", "min", v)
 
@@ -302,7 +302,7 @@ let textLength = v => attribute("", "textLength", v)
 
 let title = v => attribute("", "title", v)
 
-let to' = v => attribute("", "to", v)
+let to = v => attribute("", "to", v)
 
 let transform = v => attribute("", "transform", v)
 

--- a/src/tea_svg_attributes.resi
+++ b/src/tea_svg_attributes.resi
@@ -30,7 +30,7 @@ let baseProfile: string => Vdom.property<'msg>
 
 let bbox: string => Vdom.property<'msg>
 
-let begin': string => Vdom.property<'msg>
+let begin: string => Vdom.property<'msg>
 
 let bias: string => Vdom.property<'msg>
 
@@ -40,7 +40,7 @@ let calcMode: string => Vdom.property<'msg>
 
 let capHeight: string => Vdom.property<'msg>
 
-let class': string => Vdom.property<'msg>
+let class: string => Vdom.property<'msg>
 
 let clipPathUnits: string => Vdom.property<'msg>
 
@@ -72,7 +72,7 @@ let edgeMode: string => Vdom.property<'msg>
 
 let elevation: string => Vdom.property<'msg>
 
-let end': string => Vdom.property<'msg>
+let end: string => Vdom.property<'msg>
 
 let exponent: string => Vdom.property<'msg>
 
@@ -166,7 +166,7 @@ let max: string => Vdom.property<'msg>
 
 let media: string => Vdom.property<'msg>
 
-let method': string => Vdom.property<'msg>
+let method: string => Vdom.property<'msg>
 
 let min: string => Vdom.property<'msg>
 
@@ -298,7 +298,7 @@ let textLength: string => Vdom.property<'msg>
 
 let title: string => Vdom.property<'msg>
 
-let to': string => Vdom.property<'msg>
+let to: string => Vdom.property<'msg>
 
 let transform: string => Vdom.property<'msg>
 

--- a/src/web_window_history.res
+++ b/src/web_window_history.res
@@ -34,10 +34,10 @@ let forward = window =>
   | Some(history) => forward(history)
   }
 
-let go = (window, to') =>
+let go = (window, to) =>
   switch Js.Undefined.toOption(window["history"]) {
   | None => ()
-  | Some(history) => go(history,to')
+  | Some(history) => go(history,to)
   }
 
 let pushState = (window, state, title, url) =>

--- a/src/web_xmlhttprequest.res
+++ b/src/web_xmlhttprequest.res
@@ -141,8 +141,8 @@ let getAllResponseHeadersAsDict = (x: t): result<Belt.Map.String.t<string>, erro
 
 let getResponseHeader = (key, x) => Js.Null.toOption(x["getResponse"](key))
 
-let open_ = (method': string, url: string, ~async=true, ~user="", ~password="", x) =>
-  _open(x,method', url, async, user, password)
+let open_ = (method: string, url: string, ~async=true, ~user="", ~password="", x) =>
+  _open(x,method, url, async, user, password)
 
 let overrideMimeType = (mimetype: string, x: t): unit => overrideMimeType(x,mimetype)
 


### PR DESCRIPTION
**Functions that were changed successfully :** 
 option’
 object’
 var’
 class’
method'
begin’
class'
end'
to'

**Functions that can't be changed (reserved keyword) :**
type’
for’
in'
switch'

**Functions that can't be changed (function without apostrophe with the same name exists in the same module) :**
text’
br'

**Functions that can't be changed (exists in different files or cause errors) :**
### update' (in tea_debug.res)
update ( without the apostrophe exists in test files)

### input’ (tea_html.res)
`let input' = (~key="", ~unique="", props, nodes) => fullnode("", "input", key, unique, props, nodes)
`
removing the apostrophe caused this error in test files where there are open statements for tea_html2.
this open statement shadows the value identifier input (which is later used)

### subscriptions' (in tea_debug.res)

subscriptions (without the apostrophe) exists in tea_navigation.res

```
let subscriptions' = model =>
    model.history |> List.hd |> snd |> subscriptions |> Tea_sub.map(client_msg)

```
Inside subscriptions'  function, subscription without apostrophe is used.
Should we remove the apostrophe from this kind of functions?



### view’  (in tea_debug.res) same as subscriptions'
view (without the apostrophe) exists in tea_svg.res

```
let view' = model => {
    open Tea_html2
    module A = Tea_html2.Attributes
    module E = Tea_html2.Events
    let (selected_index, selected_model, paused) = switch model.state {
    | Running => (0, List.hd(model.history) |> snd, false)
    | Paused(index) => (index, List.nth(model.history, index) |> snd, true)
    }
```

### shutdown' (in tea_debug.res) same as subscriptions
```
let shutdown' = model => model.history |> List.hd |> snd |> shutdown |> Tea_cmd.map(client_msg)

  (init_debug, update', view', subscriptions', shutdown')
```
