### PR TITLE
fix spellcheck

### DIFF
--- a/lib/js/src/tea_html.js
+++ b/lib/js/src/tea_html.js
@@ -1476,15 +1476,12 @@ function lang(code) {
 }
 
 function spellcheck(b) {
-  if (b) {
-    return {
-            TAG: /* RawProp */0,
-            _0: "spellcheck",
-            _1: "spellcheck"
-          };
-  } else {
-    return /* NoProp */0;
-  }
+  return {
+          TAG: /* Attribute */1,
+          _0: "",
+          _1: "spellcheck",
+          _2: b ? "true" : "false"
+        };
 }
 
 function tabindex(n) {

--- a/src/tea_html.res
+++ b/src/tea_html.res
@@ -624,12 +624,7 @@ module Attributes = {
 
   let lang = code => prop("lang", code)
 
-  let spellcheck = b =>
-    if b {
-      prop("spellcheck", "spellcheck")
-    } else {
-      noProp
-    }
+  let spellcheck = (b: bool) => Vdom.attribute("", "spellcheck", string_of_bool(b))
 
   let tabindex = n => attribute("", "tabindex", string_of_int(n))
 

--- a/src/tea_html.resi
+++ b/src/tea_html.resi
@@ -491,6 +491,7 @@ module Attributes: {
   let lang: string => Vdom.property<'msg>
 
   let spellcheck: bool => Vdom.property<'msg>
+  
 
   let tabindex: int => Vdom.property<'msg>
 


### PR DESCRIPTION
Changed spellcheck from

```
  let spellcheck = b =>
    if b {
      prop("spellcheck", "spellcheck")
    } else {
      noProp
    }
```
to

`let spellcheck = (b: bool) => Vdom.attribute("", "spellcheck", string_of_bool(b))
`