### PR TITLE
Convert snake_case to camelCase in all internal names

### DIFF
--- a/lib/js/src/tea_app.js
+++ b/lib/js/src/tea_app.js
@@ -56,25 +56,25 @@ function programStateWrapper(initModel, pump, shutdown) {
           Error: new Error()
         };
   };
-  var render_events = {
+  var renderEvents = {
     contents: /* [] */0
   };
   var finalizedCBs_enqueue = handler;
   var finalizedCBs_on = function (x) {
     if (typeof x === "number") {
-      return List.iter(handler, render_events.contents);
+      return List.iter(handler, renderEvents.contents);
     }
     if (x.TAG === /* AddRenderMsg */0) {
-      render_events.contents = List.append(render_events.contents, {
+      renderEvents.contents = List.append(renderEvents.contents, {
             hd: x._0,
             tl: /* [] */0
           });
       return ;
     }
     var msg = x._0;
-    render_events.contents = List.filter(function (mg) {
+    renderEvents.contents = List.filter(function (mg) {
             return msg !== mg;
-          })(render_events.contents);
+          })(renderEvents.contents);
     
   };
   var finalizedCBs = {

--- a/lib/js/src/tea_task.js
+++ b/lib/js/src/tea_task.js
@@ -319,7 +319,7 @@ function sequence(x) {
   }
 }
 
-var testing_deop = {
+var testingDeop = {
   contents: true
 };
 
@@ -367,7 +367,7 @@ function testing(param) {
         _0: 86
       }, f);
   var r = function (param) {
-    if (testing_deop.contents) {
+    if (testingDeop.contents) {
       return /* Task */{
               _0: (function (cb) {
                   return Curry._1(cb, {
@@ -754,6 +754,6 @@ exports.map4 = map4;
 exports.map5 = map5;
 exports.map6 = map6;
 exports.sequence = sequence;
-exports.testing_deop = testing_deop;
+exports.testingDeop = testingDeop;
 exports.testing = testing;
 /* No side effect */

--- a/src/tea_app.res
+++ b/src/tea_app.res
@@ -59,16 +59,16 @@ let programStateWrapper = (initModel, pump, shutdown) => {
       }
     | Some(msgs) => pending := Some(list{msg, ...msgs})
     }
-  let render_events = ref(list{})
+  let renderEvents = ref(list{})
   let finalizedCBs: Vdom.applicationCallbacks<'msg> = (
     {
       enqueue: msg => handler(msg),
       on: x =>
         switch x {
-        | Render => List.iter(handler, render_events.contents)
-        | AddRenderMsg(msg) => render_events := List.append(render_events.contents, list{msg})
+        | Render => List.iter(handler, renderEvents.contents)
+        | AddRenderMsg(msg) => renderEvents := List.append(renderEvents.contents, list{msg})
         | RemoveRenderMsg(msg) =>
-          render_events := List.filter(mg => msg !== mg, render_events.contents)
+          renderEvents := List.filter(mg => msg !== mg, renderEvents.contents)
         },
     }: Vdom.applicationCallbacks<'msg>
   )

--- a/src/tea_debug.res
+++ b/src/tea_debug.res
@@ -1,4 +1,4 @@
-type debug_msg<'msg> =
+type debugMsg<'msg> =
   | ClientMsg('msg)
   | TogglePaused
   | SelectHistoryItem(int)
@@ -22,11 +22,11 @@ let debug = (
   subscriptions: 'model => Tea_sub.t<'msg>,
   shutdown: 'model => Tea_cmd.t<'msg>,
 ): (
-  (('model, Tea_cmd.t<'msg>)) => (debug_model<'model>, Tea_cmd.t<debug_msg<'msg>>),
-  (debug_model<'model>, debug_msg<'msg>) => (debug_model<'model>, Tea_cmd.t<debug_msg<'msg>>),
-  debug_model<'model> => Vdom.t<debug_msg<'msg>>,
-  debug_model<'model> => Tea_sub.t<debug_msg<'msg>>,
-  debug_model<'model> => Tea_cmd.t<debug_msg<'msg>>,
+  (('model, Tea_cmd.t<'msg>)) => (debug_model<'model>, Tea_cmd.t<debugMsg<'msg>>),
+  (debug_model<'model>, debugMsg<'msg>) => (debug_model<'model>, Tea_cmd.t<debugMsg<'msg>>),
+  debug_model<'model> => Vdom.t<debugMsg<'msg>>,
+  debug_model<'model> => Tea_sub.t<debugMsg<'msg>>,
+  debug_model<'model> => Tea_cmd.t<debugMsg<'msg>>,
 ) => {
   let initDebug = ((cmodel, cmd)) => (
     {
@@ -361,7 +361,7 @@ let debug = (
 let debugProgram: (
   'msg => string,
   Tea_app.program<'flags, 'model, 'msg>,
-) => Tea_app.program<'flags, debug_model<'model>, debug_msg<'msg>> = (
+) => Tea_app.program<'flags, debug_model<'model>, debugMsg<'msg>> = (
   string_of_msg,
   {init, update, view, subscriptions, shutdown},
 ) => {
@@ -385,7 +385,7 @@ let debugProgram: (
 let debugNavigationProgram: (
   'msg => string,
   Tea_navigation.navigationProgram<'flags, 'model, 'msg>,
-) => Tea_navigation.navigationProgram<'flags, debug_model<'model>, debug_msg<'msg>> = (
+) => Tea_navigation.navigationProgram<'flags, debug_model<'model>, debugMsg<'msg>> = (
   string_of_msg,
   {init, update, view, subscriptions, shutdown},
 ) => {
@@ -411,7 +411,7 @@ let beginnerProgram: (
   'msg => string,
   Js.null_undefined<Web.Node.t>,
   unit,
-) => Tea_app.programInterface<debug_msg<'msg>> = (
+) => Tea_app.programInterface<debugMsg<'msg>> = (
   {model, update, view},
   string_of_msg,
   pnode,
@@ -435,7 +435,7 @@ let standardProgram: (
   'msg => string,
   Js.null_undefined<Web.Node.t>,
   'flags,
-) => Tea_app.programInterface<debug_msg<'msg>> = (
+) => Tea_app.programInterface<debugMsg<'msg>> = (
   {init, update, view, subscriptions},
   string_of_msg,
   pnode,
@@ -459,7 +459,7 @@ let program: (
   'msg => string,
   Js.null_undefined<Web.Node.t>,
   'flags,
-) => Tea_app.programInterface<debug_msg<'msg>> = (
+) => Tea_app.programInterface<debugMsg<'msg>> = (
   {init, update, view, subscriptions, shutdown},
   string_of_msg,
   pnode,
@@ -484,7 +484,7 @@ let navigationProgram: (
   'msg => string,
   Js.null_undefined<Web.Node.t>,
   'flags,
-) => Tea_app.programInterface<debug_msg<'msg>> = (
+) => Tea_app.programInterface<debugMsg<'msg>> = (
   location_to_msg,
   {init, update, view, subscriptions, shutdown},
   string_of_msg,

--- a/src/tea_debug.resi
+++ b/src/tea_debug.resi
@@ -1,6 +1,6 @@
-type debug_msg<'msg> = ClientMsg('msg) | TogglePaused | SelectHistoryItem(int) | ToggleDetails
+type debugMsg<'msg> = ClientMsg('msg) | TogglePaused | SelectHistoryItem(int) | ToggleDetails
 
-let clientMsg: 'msg => debug_msg<'msg>
+let clientMsg: 'msg => debugMsg<'msg>
 
 type state = Running | Paused(int)
 type debug_model<'model> = {history: list<(string, 'model)>, state: state, show_details: bool}
@@ -12,44 +12,44 @@ let debug: (
   'model => Tea_sub.t<'msg>,
   'model => Tea_cmd.t<'msg>,
 ) => (
-  (('model, Tea_cmd.t<'msg>)) => (debug_model<'model>, Tea_cmd.t<debug_msg<'msg>>),
-  (debug_model<'model>, debug_msg<'msg>) => (debug_model<'model>, Tea_cmd.t<debug_msg<'msg>>),
-  debug_model<'model> => Vdom.t<debug_msg<'msg>>,
-  debug_model<'model> => Tea_sub.t<debug_msg<'msg>>,
-  debug_model<'model> => Tea_cmd.t<debug_msg<'msg>>,
+  (('model, Tea_cmd.t<'msg>)) => (debug_model<'model>, Tea_cmd.t<debugMsg<'msg>>),
+  (debug_model<'model>, debugMsg<'msg>) => (debug_model<'model>, Tea_cmd.t<debugMsg<'msg>>),
+  debug_model<'model> => Vdom.t<debugMsg<'msg>>,
+  debug_model<'model> => Tea_sub.t<debugMsg<'msg>>,
+  debug_model<'model> => Tea_cmd.t<debugMsg<'msg>>,
 )
 
 let debugProgram: ('msg => string, Tea_app.program<'flags, 'model, 'msg>) => Tea_app.program<
   'flags,
   debug_model<'model>,
-  debug_msg<'msg>,
+  debugMsg<'msg>,
 >
 
 let debugNavigationProgram: (
   'msg => string,
   Tea_navigation.navigationProgram<'flags, 'model, 'msg>,
-) => Tea_navigation.navigationProgram<'flags, debug_model<'model>, debug_msg<'msg>>
+) => Tea_navigation.navigationProgram<'flags, debug_model<'model>, debugMsg<'msg>>
 
 let beginnerProgram: (
   Tea_app.beginnerProgram<'model, 'msg>,
   'msg => string,
   Js.null_undefined<Web.Node.t>,
   unit,
-) => Tea_app.programInterface<debug_msg<'msg>>
+) => Tea_app.programInterface<debugMsg<'msg>>
 
 let standardProgram: (
   Tea_app.standardProgram<'flags, 'model, 'msg>,
   'msg => string,
   Js.null_undefined<Web.Node.t>,
   'flags,
-) => Tea_app.programInterface<debug_msg<'msg>>
+) => Tea_app.programInterface<debugMsg<'msg>>
 
 let program: (
   Tea_app.program<'flags, 'model, 'msg>,
   'msg => string,
   Js.null_undefined<Web.Node.t>,
   'flags,
-) => Tea_app.programInterface<debug_msg<'msg>>
+) => Tea_app.programInterface<debugMsg<'msg>>
 
 let navigationProgram: (
   Web.Location.location => 'msg,
@@ -57,4 +57,4 @@ let navigationProgram: (
   'msg => string,
   Js.null_undefined<Web.Node.t>,
   'flags,
-) => Tea_app.programInterface<debug_msg<'msg>>
+) => Tea_app.programInterface<debugMsg<'msg>>

--- a/src/tea_http.res
+++ b/src/tea_http.res
@@ -1,4 +1,4 @@
-type response_status = {
+type responseStatus = {
   code: int,
   message: string,
 }
@@ -9,7 +9,7 @@ type responseBody = Web.XMLHttpRequest.responseBody
 
 type response = {
   url: string,
-  status: response_status,
+  status: responseStatus,
   headers: Belt.Map.String.t<string>,
   body: responseBody,
 }

--- a/src/tea_http.resi
+++ b/src/tea_http.resi
@@ -1,4 +1,4 @@
-type response_status = {code: int, message: string}
+type responseStatus = {code: int, message: string}
 
 type requestBody = Web.XMLHttpRequest.body
 type bodyType = Web.XMLHttpRequest.responseType
@@ -6,7 +6,7 @@ type responseBody = Web.XMLHttpRequest.responseBody
 
 type response = {
   url: string,
-  status: response_status,
+  status: responseStatus,
   headers: Belt.Map.String.t<string>,
   body: responseBody,
 }

--- a/src/tea_promise.res
+++ b/src/tea_promise.res
@@ -37,8 +37,8 @@ let result = (promise, msg) => {
         |> Js.Promise.catch(x =>
           switch x {
           | err =>
-            let err_to_string = err => j`$err`
-            let reject = enq(Error(err_to_string(err)))
+            let errToString = err => j`$err`
+            let reject = enq(Error(errToString(err)))
             Js.Promise.resolve(reject)
           }
         )

--- a/src/tea_task.res
+++ b/src/tea_task.res
@@ -139,7 +139,7 @@ let rec sequence = x =>
   | list{task, ...remainingTasks} => map2((l, r) => list{l, ...r}, task, sequence(remainingTasks))
   }
 
-let testing_deop = ref(true)
+let testingDeop = ref(true)
 
 let testing = () => {
   let doTest = (expected, Task(task)) => {
@@ -156,7 +156,7 @@ let testing = () => {
   let f = fail(86)
   let () = doTest(Error(86), f)
   let r = () =>
-    if testing_deop.contents {
+    if testingDeop.contents {
       succeed(42)
     } else {
       fail(3.14)

--- a/src/tea_task.resi
+++ b/src/tea_task.resi
@@ -53,6 +53,6 @@ let map6: (
 
 let sequence: list<t<'msg, 'b>> => t<list<'msg>, 'b>
 
-let testing_deop: ref<bool>
+let testingDeop: ref<bool>
 
 let testing: unit => unit

--- a/src/vdom.res
+++ b/src/vdom.res
@@ -671,12 +671,12 @@ let wrapCallbacks:
       ref,
       {
         enqueue: (msg: a) => {
-          let new_msg = func(msg)
-          callbacks.contents.enqueue(new_msg)
+          let newMsg = func(msg)
+          callbacks.contents.enqueue(newMsg)
         },
         on: smsg => {
-          let new_smsg = wrapCallbacksOn(func, smsg)
-          callbacks.contents.on(new_smsg)
+          let newSmsg = wrapCallbacksOn(func, smsg)
+          callbacks.contents.on(newSmsg)
         },
       },
     )


### PR DESCRIPTION
**tea_app.res**
render_events ->renderEvents

**tea_debug.res**
debug_msg -> debugMsg

**tea_http.res**
response_status -> responseStatus

**tea_promise.res**
err_to_string -> errToString

**tea_task.res**
testing_deop -> testingDeop

**vdom.res**
new_msg -> newMsg
new_smsg -> newSmsg

The ones in the web files were not changed. Hopefully we will not use them anymore after completing issue #4.